### PR TITLE
chore: update eggs version to 0.3.8

### DIFF
--- a/docs/eggs/configuration.md
+++ b/docs/eggs/configuration.md
@@ -45,7 +45,7 @@ Here is a template egg configuration file with all available fields:
 > Note: with a JSON file, you can validate your config by adding the following field:
 >
 > ```json
-> "$schema": "https://x.nest.land/eggs@0.3.1/src/schema.json",
+> "$schema": "https://x.nest.land/eggs@0.3.8/src/schema.json",
 > ```
 
 **YAML**:

--- a/docs/eggs/installation.md
+++ b/docs/eggs/installation.md
@@ -5,7 +5,7 @@ title: Installation
 To publish your first module to nest.land, you will need our CLI, **eggs**. You can install it using this command:
 
 ```shell script
-deno install -Afq --unstable https://x.nest.land/eggs@0.3.7/eggs.ts
+deno install -Afq --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
 ```
 
 Please make sure to use the `-A` flag to grant all permissions to eggs, so you can enjoy all features seamlessly.

--- a/docs/eggs/publishing-a-module.md
+++ b/docs/eggs/publishing-a-module.md
@@ -52,7 +52,7 @@ Additional options:
 You just need to import the `publish` function from the latest version of eggs.
 
 ```ts
-import { publish } from "https://x.nest.land/eggs@0.3.1/src/commands/publish.ts";
+import { publish } from "https://x.nest.land/eggs@0.3.8/src/commands/publish.ts";
 
 const config = {
   description: "Your brief module description",
@@ -86,7 +86,7 @@ jobs:
       - uses: denolib/setup-deno@master
         with:
           deno-version: 1.4.6
-      - run: deno install -Af --unstable https://x.nest.land/eggs@0.3.1/eggs.ts
+      - run: deno install -Af --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs link ${{ secrets.NESTAPIKEY }}

--- a/docs/eggs/updating-all-of-your-dependencies.md
+++ b/docs/eggs/updating-all-of-your-dependencies.md
@@ -53,6 +53,6 @@ After `eggs update`:
 ```ts
 import * as colors from "https://deno.land/std@0.62.0/fmt/colors.ts";
 import * as bcrypt from "https://deno.land/x/bcrypt@v0.2.1/mod.ts";
-import * as eggs from "https://x.nest.land/eggs@0.2.3/mod.ts";
+import * as eggs from "https://x.nest.land/eggs@0.3.8/mod.ts";
 import * as http from "https://deno.land/std/http/mod.ts";
 ```

--- a/docs/eggs/upgrade-eggs.md
+++ b/docs/eggs/upgrade-eggs.md
@@ -11,5 +11,5 @@ eggs upgrade
 Alternatively you can use the install command with the `-f` flag to upgrade.
 
 ```shell script
-deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.2.3/mod.ts
+deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.8/mod.ts
 ```


### PR DESCRIPTION
update `eggs` versions in the documents to the latest version (0.3.8).