### PR TITLE
fix(docs): update ci example

### DIFF
--- a/docs/eggs/publishing-a-module.md
+++ b/docs/eggs/publishing-a-module.md
@@ -80,17 +80,21 @@ on:
 
 jobs:
   publish-egg:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: denolib/setup-deno@master
+      - name: Setup Actions
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.4.6
-      - run: deno install -Af --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
-      - run: |
-          export PATH="/home/runner/.deno/bin:$PATH"
+           deno-version: v1.5.x
+          
+      - name: Release
+        run: |
+          deno install -Af --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
           eggs link ${{ secrets.NESTAPIKEY }}
-          eggs publish
+          eggs publish --yes --no-check --version $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
 To see how to use this, visit our [eggs-ci repository](https://github.com/nestdotland/eggs-ci).

--- a/docs/eggs/publishing-a-module.md
+++ b/docs/eggs/publishing-a-module.md
@@ -80,15 +80,15 @@ on:
 
 jobs:
   publish-egg:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Actions
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        uses: denolib/setup-deno@v2
+        uses: maximousblk/setup-deno@v1
         with:
-           deno-version: v1.5.x
+           deno-version: 1.13
           
       - name: Release
         run: |


### PR DESCRIPTION
Hello :)

This updates the GitHub Actions example code in the docs to a working version, because the current one doesn't appear to be working properly.

I updated the `uses: denolib/setup-deno` step and removed the export to PATH which shouldn't be needed anymore, also I added  parameters to `eggs publish` from the [ship.yml](https://github.com/nestdotland/eggs-ci/blob/master/ship.yml) example. These changes made the publish step work in my own CI pipeline every time I create a new release, so thought this might be helpful to update.