### PR TITLE
bump version in install command

### DIFF
--- a/docs/eggs/configuration.md
+++ b/docs/eggs/configuration.md
@@ -47,7 +47,7 @@ Here is a template egg configuration file with all available fields:
 With a JSON file, you can validate your config by adding the following field:
 
 ```json
-"$schema": "https://x.nest.land/eggs@0.3.8/src/schema.json",
+"$schema": "https://x.nest.land/eggs@0.3.10/src/schema.json",
 ```
 
 :::

--- a/docs/eggs/installation.md
+++ b/docs/eggs/installation.md
@@ -5,7 +5,7 @@ title: Installation
 To publish your first module to nest.land, you will need our CLI, `eggs`. You can install it using this command:
 
 ```shell script
-deno install -Af --unstable https://x.nest.land/eggs@0.3.9/eggs.ts
+deno install -Af --unstable https://x.nest.land/eggs@0.3.10/eggs.ts
 ```
 
 Please make sure to use the `-A` flag to grant all permissions to eggs, so you can enjoy all features seamlessly.

--- a/docs/eggs/installation.md
+++ b/docs/eggs/installation.md
@@ -5,7 +5,7 @@ title: Installation
 To publish your first module to nest.land, you will need our CLI, `eggs`. You can install it using this command:
 
 ```shell script
-deno install -Af --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
+deno install -Af --unstable https://x.nest.land/eggs@0.3.9/eggs.ts
 ```
 
 Please make sure to use the `-A` flag to grant all permissions to eggs, so you can enjoy all features seamlessly.

--- a/docs/eggs/publishing-a-module.md
+++ b/docs/eggs/publishing-a-module.md
@@ -56,7 +56,7 @@ Additional options:
 You just need to import the `publish` function from the latest version of eggs.
 
 ```ts
-import { publish } from 'https://x.nest.land/eggs@0.3.8/src/commands/publish.ts';
+import { publish } from 'https://x.nest.land/eggs@0.3.10/src/commands/publish.ts';
 
 const config = {
   description: 'Your brief module description',
@@ -96,7 +96,7 @@ jobs:
 
       - name: Publish
         run: |
-          deno install -Af --unstable https://x.nest.land/eggs@0.3.8/eggs.ts
+          deno install -Af --unstable https://x.nest.land/eggs@0.3.10/eggs.ts
           eggs link ${{ secrets.NESTAPIKEY }}
           eggs publish --yes --no-check --version $(git describe --tags $(git rev-list --tags --max-count=1))
 ```

--- a/docs/eggs/updating-all-of-your-dependencies.md
+++ b/docs/eggs/updating-all-of-your-dependencies.md
@@ -57,6 +57,6 @@ After `eggs update`:
 ```ts
 import * as colors from 'https://deno.land/std@0.62.0/fmt/colors.ts';
 import * as bcrypt from 'https://deno.land/x/bcrypt@v0.2.1/mod.ts';
-import * as eggs from 'https://x.nest.land/eggs@0.3.8/mod.ts';
+import * as eggs from 'https://x.nest.land/eggs@0.3.10/mod.ts';
 import * as http from 'https://deno.land/std/http/mod.ts';
 ```

--- a/docs/eggs/upgrade-eggs.md
+++ b/docs/eggs/upgrade-eggs.md
@@ -11,5 +11,5 @@ eggs upgrade
 Alternatively you can use the install command with the `-f` flag to upgrade.
 
 ```shell script
-deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.8/mod.ts
+deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.10/mod.ts
 ```


### PR DESCRIPTION
mainly did this because of the "Make sure you are using Deno `v1.12.0` or later." note
0.3.8 does not work with 1.12 or later, 0.3.9 does